### PR TITLE
R4R: Update consensus keys prefix and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To install `tmkms`, do the following:
 2. Run the following to install Tendermint KMS using Rust's `cargo` tool:
 
 ```
-$ cargo install tmkms
+$ cargo install --features yubihsm,ledgertm --path .
 ```
 
 3. Copy the example `tmkms.toml` file to a local directory (e.g. `~/.tmkms`):

--- a/tendermint-rs/src/public_keys.rs
+++ b/tendermint-rs/src/public_keys.rs
@@ -37,7 +37,7 @@ impl Display for ConsensusKey {
         match self {
             ConsensusKey::Ed25519(ref pk) => {
                 key_bytes.extend(pk.as_bytes());
-                bech32::encode("cosmosvalconspub", &key_bytes).fmt(f)
+                bech32::encode("icp", &key_bytes).fmt(f)
             }
         }
     }


### PR DESCRIPTION
Set consensus keys prefix = icp.
Add to config file later.